### PR TITLE
fix - resolve openpdf missing from Cloud Run fat JAR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Build with Gradle
-        run: ./gradlew build -x test
+        run: ./gradlew clean build -x test
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,8 @@ configurations {
 }
 
 repositories {
-    maven { url 'https://jitpack.io' }
     mavenCentral()
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {


### PR DESCRIPTION
Move mavenCentral() before JitPack so com.github.librepdf:openpdf is resolved from Maven Central (reliable) instead of JitPack (which can produce broken JARs on fresh CI runners). Add 'clean' to the CI Gradle build to prevent stale cached artifacts from being packaged.